### PR TITLE
Add print statements to inference_data.head() in the notebook

### DIFF
--- a/mlsec-workshop-ipinsights.ipynb
+++ b/mlsec-workshop-ipinsights.ipynb
@@ -250,7 +250,7 @@
     "# Run inference on training (normal) data for sanity check\n",
     "s3_infer_data = 's3://{}/{}'.format(bucket, train_key)\n",
     "inference_data = pd.read_csv(s3_infer_data)\n",
-    "inference_data.head()\n",
+    "print(inference_data.head())\n",
     "train_dot_products = predictor.predict(inference_data.values)"
    ]
   },
@@ -300,7 +300,7 @@
     "infer_key = os.path.join(prefix, 'infer', 'guardduty_tuples.csv')\n",
     "s3_infer_data = 's3://{}/{}'.format(bucket, infer_key)\n",
     "inference_data = pd.read_csv(s3_infer_data)\n",
-    "inference_data.head()\n",
+    "print(inference_data.head())\n",
     "GuardDuty_dot_products = predictor.predict(inference_data.values)"
    ]
   },


### PR DESCRIPTION
The notebook contains inference_data.head() statements which are, I suppose, intended for debugging/printing reasons. However, without print statements surrounding them the result won't be presented. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
