### PR TITLE
Fix a typo

### DIFF
--- a/mlsec-workshop-ipinsights.ipynb
+++ b/mlsec-workshop-ipinsights.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "### ACTION: Configure Amazon S3 Bucket\n",
     "\n",
-    "Before going further, we to specify the S3 bucket that SageMaker will use for input and output data for the model, which will be the bucket where our training and inference tuples from CloudTrail logs and GuardDuty findings, respectively, are located. Edit the following cell to specify the name of the bucket and then run it; you do not need to change the prefix."
+    "Before going further, we need to specify the S3 bucket that SageMaker will use for input and output data for the model, which will be the bucket where our training and inference tuples from CloudTrail logs and GuardDuty findings, respectively, are located. Edit the following cell to specify the name of the bucket and then run it; you do not need to change the prefix."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The jupyter notebook had a typo.  It was missing the word need.  That was the only change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
